### PR TITLE
Update ai-codereviewer to use gpt-4o-mini model

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -18,5 +18,5 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_API_MODEL: "gpt-4o-mini"
           LANGUAGE: "Japanese"
-          max_tokens: "8096"
+          max_tokens: 8096
           exclude: "yarn.lock,dist/**"

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -12,9 +12,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Code Review
-        uses: freeedcom/ai-codereviewer@main
+        uses: hilltop-tech/ai-codereviewer@main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_API_MODEL: "gpt-4-1106-preview"
+          OPENAI_API_MODEL: "gpt-4o-mini"
           exclude: "yarn.lock,dist/**"

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -17,4 +17,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_API_MODEL: "gpt-4o-mini"
+          LANGUAGE: "Japanese"
+          max_tokens: "8096"
           exclude: "yarn.lock,dist/**"


### PR DESCRIPTION
This pull request updates the ai-codereviewer workflow to use the gpt-4o-mini model instead of the previous gpt-4-1106-preview model. This change ensures that the code review process is performed using the latest and most optimized model available.